### PR TITLE
Patch/wallet sync cancellation

### DIFF
--- a/src/common/threadpool.cpp
+++ b/src/common/threadpool.cpp
@@ -101,7 +101,7 @@ threadpool::waiter::~waiter()
 
 void threadpool::waiter::wait() {
   boost::unique_lock<boost::mutex> lock(mt);
-  while(num) cv.wait(lock);
+  while(num) cv.timed_wait(lock, boost::posix_time::milliseconds(1000));
 }
 
 void threadpool::waiter::inc() {
@@ -112,8 +112,7 @@ void threadpool::waiter::inc() {
 void threadpool::waiter::dec() {
   const boost::unique_lock<boost::mutex> lock(mt);
   num--;
-  if (!num)
-    cv.notify_one();
+  cv.notify_all();
 }
 
 void threadpool::run() {

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -49,6 +49,7 @@
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_core/cryptonote_tx_utils.h"
 #include "common/unordered_containers_boost_serialization.h"
+#include "common/threadpool.h"
 #include "crypto/chacha.h"
 #include "crypto/hash.h"
 #include "ringct/rctTypes.h"
@@ -67,7 +68,8 @@ class Serialization_portability_wallet_Test;
 namespace tools
 {
   class ringdb;
-
+  class threadpool;
+  
   class i_wallet2_callback
   {
   public:
@@ -591,7 +593,7 @@ namespace tools
     bool init(std::string daemon_address = "http://localhost:8080",
       boost::optional<epee::net_utils::http::login> daemon_login = boost::none, uint64_t upper_transaction_size_limit = 0, bool ssl = false);
 
-    void stop() { m_run.store(false, std::memory_order_relaxed); }
+    void stop();
 
     i_wallet2_callback* callback() const { return m_callback; }
     void callback(i_wallet2_callback* callback) { m_callback = callback; }
@@ -1249,6 +1251,8 @@ namespace tools
     std::string m_ring_database;
     bool m_ring_history_saved;
     std::unique_ptr<ringdb> m_ringdb;
+
+    tools::threadpool::waiter m_waiter;
   };
 }
 BOOST_CLASS_VERSION(tools::wallet2, 24)


### PR DESCRIPTION
1. wait for threadpool to exit all tasks belonging to wallet, when wallet2::stop() is called
2. early exit from process_blocks when wallet2::stop() is called
