### PR TITLE
Patch/wallet api rescan bc

### DIFF
--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -113,6 +113,8 @@ public:
     bool synchronized() const;
     bool refresh();
     void refreshAsync();
+    bool rescanBlockchain();
+    void rescanBlockchainAsync();
     void setAutoRefreshInterval(int millis);
     int autoRefreshInterval() const;
     void setRefreshFromBlockHeight(uint64_t refresh_from_block_height);
@@ -227,6 +229,8 @@ private:
     std::atomic<bool> m_refreshEnabled;
     std::atomic<bool> m_refreshThreadDone;
     std::atomic<int>  m_refreshIntervalMillis;
+
+    std::atomic<bool> m_refreshShouldRescan;
     // synchronizing  refresh loop;
     boost::mutex        m_refreshMutex;
 

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -640,6 +640,18 @@ struct Wallet
     virtual void refreshAsync() = 0;
 
     /**
+     * @brief rescanBlockchain - rescans the wallet, updating transactions from daemon
+     * @return - true if refreshed successfully;
+     */
+    virtual bool rescanBlockchain() = 0;
+
+    /**
+     * @brief rescanBlockchainAsync - rescans wallet asynchronously, starting from genesys
+     */
+    virtual void rescanBlockchainAsync() = 0;
+
+
+    /**
      * @brief setAutoRefreshInterval - setup interval for automatic refresh.
      * @param seconds - interval in millis. if zero or less than zero - automatic refresh disabled;
      */


### PR DESCRIPTION
see https://github.com/mmitkevich/monero-multisig-api-example/blob/wallet-api-rescan-bc/main.cpp#L177 for test code

Relevant log:
```
Mikhails-MacBook-Pro:monero-multisig-api-example mike$ ./build/app-monero balance|egrep "\*\*\*|rescan|updated blockchain"
*** START_REFRESH
2018-10-12 07:15:37,224 TRACE [WalletAPI] [void Monero::WalletImpl::doRefresh()] [/Users/mike/monero/src/wallet/api/wallet.cpp:1980] doRefresh: doRefresh, rescan = 0
*** RESCAN_BLOCKCHAIN_ASYNC
*** PAUSE_REFRESH
*** START_REFRESH
*** WAIT_REFRESH - 1
updated blockchain height: 1613392
updated blockchain height: 1624072
... more update blockchain here
updated blockchain height: 1659187
updated blockchain height: 1659211
updated blockchain height: 1659293
2018-10-12 07:20:44,847 TRACE [WalletAPI] [void Monero::WalletImpl::doRefresh()] [/Users/mike/monero/src/wallet/api/wallet.cpp:1980] doRefresh: doRefresh, rescan = 1
updated blockchain height: 1604514
updated blockchain height: 1615386
... more update blockchain here
updated blockchain height: 1659211
updated blockchain height: 1659293
*** refreshed
*** WAIT_REFRESH - DONE
```
suggests we had two doRefresh calls, first without rescan and second with rescan.

